### PR TITLE
feat: add MCP GitHub file operations server for pr-update check triggers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -197,10 +197,22 @@ runs:
     - name: Prepare tool configuration
       id: prepare_tools
       shell: bash
+      env:
+        DEVSY_MODE: ${{ inputs.mode }}
       run: |
         /tmp/devsy-action-env/bin/python ${{ github.action_path }}/src/prepare_tools.py \
           --allowed-tools "${{ inputs.allowed_tools }}" \
           --disallowed-tools "${{ inputs.disallowed_tools }}"
+
+    - name: Prepare MCP configuration
+      id: prepare_mcp
+      shell: bash
+      env:
+        DEVSY_MODE: ${{ inputs.mode }}
+        GITHUB_TOKEN: ${{ steps.token_exchange.outputs.github_token }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+      run: |
+        /tmp/devsy-action-env/bin/python ${{ github.action_path }}/src/prepare_mcp_config.py
 
     - name: Run Claude Code with git and gh tools
       id: run_claude
@@ -217,6 +229,7 @@ runs:
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}
         claude_env: ${{ inputs.claude_env }}
+        mcp_config: ${{ steps.prepare_mcp.outputs.mcp_config }}
       env:
         # GitHub CLI authentication
         GITHUB_TOKEN: ${{ steps.token_exchange.outputs.github_token }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 requests>=2.31.0
+mcp[cli]>=1.0.0
+uvloop>=0.17.0
 
 # Development dependencies
 pytest>=7.0.0

--- a/src/mcp/github_file_ops_server.py
+++ b/src/mcp/github_file_ops_server.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+MCP Server for GitHub file operations.
+
+This server provides tools for committing and deleting files in GitHub repositories
+using the GitHub API directly. This approach can trigger GitHub checks when normal
+git operations from actions might not.
+"""
+
+import asyncio
+import os
+import sys
+import json
+import base64
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+import requests
+
+from mcp.server.fastmcp import FastMCP
+
+# Initialize the MCP server
+mcp = FastMCP("GitHub File Operations")
+
+
+def make_github_request(
+    method: str,
+    url: str,
+    token: str,
+    data: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Make a request to the GitHub API."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28"
+    }
+    
+    response = requests.request(
+        method=method,
+        url=url,
+        headers=headers,
+        json=data if data else None
+    )
+    
+    if not response.ok:
+        raise Exception(f"GitHub API error: {response.status_code} {response.text}")
+    
+    return response.json() if response.text else {}
+
+
+@mcp.tool()
+def commit_files(
+    message: str,
+    files: List[Dict[str, str]],
+    owner: Optional[str] = None,
+    repo: Optional[str] = None,
+    branch: Optional[str] = None,
+    github_token: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Commit files to a GitHub repository.
+    
+    Args:
+        message: Commit message
+        files: List of file dictionaries with 'path' and 'content' keys
+        owner: Repository owner (optional, defaults to env var)
+        repo: Repository name (optional, defaults to env var)
+        branch: Branch name (optional, defaults to env var)
+        github_token: GitHub authentication token (optional, defaults to env var)
+    
+    Returns:
+        Dictionary with commit details including SHA and URL
+    """
+    # Use environment variables as defaults
+    owner = owner or os.environ.get('REPO_OWNER')
+    repo = repo or os.environ.get('REPO_NAME')
+    branch = branch or os.environ.get('BRANCH_NAME')
+    github_token = github_token or os.environ.get('GITHUB_TOKEN')
+    
+    if not all([owner, repo, branch, github_token]):
+        return {
+            "success": False,
+            "error": "Missing required parameters: owner, repo, branch, or github_token"
+        }
+    
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+    
+    try:
+        # Get the current branch reference
+        ref_data = make_github_request(
+            "GET",
+            f"{base_url}/git/refs/heads/{branch}",
+            github_token
+        )
+        base_sha = ref_data["object"]["sha"]
+        
+        # Get the base commit
+        base_commit = make_github_request(
+            "GET",
+            f"{base_url}/git/commits/{base_sha}",
+            github_token
+        )
+        base_tree_sha = base_commit["tree"]["sha"]
+        
+        # Create tree entries for the files
+        tree_entries = []
+        for file in files:
+            # Base64 encode the content
+            content_b64 = base64.b64encode(file["content"].encode()).decode()
+            tree_entries.append({
+                "path": file["path"],
+                "mode": "100644",  # Regular file
+                "type": "blob",
+                "content": file["content"]
+            })
+        
+        # Create a new tree
+        tree_data = make_github_request(
+            "POST",
+            f"{base_url}/git/trees",
+            github_token,
+            {
+                "base_tree": base_tree_sha,
+                "tree": tree_entries
+            }
+        )
+        new_tree_sha = tree_data["sha"]
+        
+        # Create the commit
+        commit_data = make_github_request(
+            "POST",
+            f"{base_url}/git/commits",
+            github_token,
+            {
+                "message": message,
+                "tree": new_tree_sha,
+                "parents": [base_sha]
+            }
+        )
+        new_commit_sha = commit_data["sha"]
+        
+        # Update the branch reference
+        ref_update = make_github_request(
+            "PATCH",
+            f"{base_url}/git/refs/heads/{branch}",
+            github_token,
+            {
+                "sha": new_commit_sha,
+                "force": False
+            }
+        )
+        
+        return {
+            "success": True,
+            "sha": new_commit_sha,
+            "url": commit_data["html_url"],
+            "message": f"Successfully committed {len(files)} file(s)"
+        }
+        
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e)
+        }
+
+
+@mcp.tool()
+def delete_files(
+    message: str,
+    paths: List[str],
+    owner: Optional[str] = None,
+    repo: Optional[str] = None,
+    branch: Optional[str] = None,
+    github_token: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Delete files from a GitHub repository.
+    
+    Args:
+        message: Commit message
+        paths: List of file paths to delete
+        owner: Repository owner (optional, defaults to env var)
+        repo: Repository name (optional, defaults to env var)
+        branch: Branch name (optional, defaults to env var)
+        github_token: GitHub authentication token (optional, defaults to env var)
+    
+    Returns:
+        Dictionary with commit details including SHA and URL
+    """
+    # Use environment variables as defaults
+    owner = owner or os.environ.get('REPO_OWNER')
+    repo = repo or os.environ.get('REPO_NAME')
+    branch = branch or os.environ.get('BRANCH_NAME')
+    github_token = github_token or os.environ.get('GITHUB_TOKEN')
+    
+    if not all([owner, repo, branch, github_token]):
+        return {
+            "success": False,
+            "error": "Missing required parameters: owner, repo, branch, or github_token"
+        }
+    
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+    
+    try:
+        # Get the current branch reference
+        ref_data = make_github_request(
+            "GET",
+            f"{base_url}/git/refs/heads/{branch}",
+            github_token
+        )
+        base_sha = ref_data["object"]["sha"]
+        
+        # Get the base commit
+        base_commit = make_github_request(
+            "GET",
+            f"{base_url}/git/commits/{base_sha}",
+            github_token
+        )
+        base_tree_sha = base_commit["tree"]["sha"]
+        
+        # Get the current tree to find all files
+        current_tree = make_github_request(
+            "GET",
+            f"{base_url}/git/trees/{base_tree_sha}?recursive=true",
+            github_token
+        )
+        
+        # Create new tree entries, excluding the files to delete
+        tree_entries = []
+        deleted_count = 0
+        
+        for item in current_tree["tree"]:
+            if item["path"] not in paths:
+                # Keep this file
+                tree_entries.append({
+                    "path": item["path"],
+                    "mode": item["mode"],
+                    "type": item["type"],
+                    "sha": item["sha"]
+                })
+            else:
+                deleted_count += 1
+        
+        # Create a new tree without the deleted files
+        tree_data = make_github_request(
+            "POST",
+            f"{base_url}/git/trees",
+            github_token,
+            {
+                "tree": tree_entries
+            }
+        )
+        new_tree_sha = tree_data["sha"]
+        
+        # Create the commit
+        commit_data = make_github_request(
+            "POST",
+            f"{base_url}/git/commits",
+            github_token,
+            {
+                "message": message,
+                "tree": new_tree_sha,
+                "parents": [base_sha]
+            }
+        )
+        new_commit_sha = commit_data["sha"]
+        
+        # Update the branch reference
+        ref_update = make_github_request(
+            "PATCH",
+            f"{base_url}/git/refs/heads/{branch}",
+            github_token,
+            {
+                "sha": new_commit_sha,
+                "force": False
+            }
+        )
+        
+        return {
+            "success": True,
+            "sha": new_commit_sha,
+            "url": commit_data["html_url"],
+            "message": f"Successfully deleted {deleted_count} file(s)"
+        }
+        
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e)
+        }
+
+
+if __name__ == "__main__":
+    # Run the server
+    try:
+        import uvloop
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    except ImportError:
+        # uvloop is optional, fall back to default event loop
+        pass
+    
+    # Run the MCP server
+    asyncio.run(mcp.run())

--- a/src/prepare_mcp_config.py
+++ b/src/prepare_mcp_config.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Prepare MCP configuration for Claude Code execution.
+
+This script generates MCP server configuration for GitHub file operations
+that can trigger checks when normal git operations might not.
+"""
+
+import json
+import os
+import sys
+
+
+def generate_mcp_config(mode: str, github_token: str) -> str:
+    """
+    Generate MCP configuration based on the action mode.
+    
+    Args:
+        mode: The action mode (pr-gen, pr-update, plan-gen)
+        github_token: GitHub authentication token
+        
+    Returns:
+        JSON string containing MCP configuration
+    """
+    # Only enable MCP server for pr-update mode
+    if mode != "pr-update":
+        return "{}"
+    
+    # Extract repository information from environment
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if not repo or "/" not in repo:
+        print("⚠️  Could not determine repository owner/name from GITHUB_REPOSITORY")
+        return "{}"
+    
+    owner, repo_name = repo.split("/", 1)
+    branch = os.environ.get("GITHUB_HEAD_REF") or os.environ.get("GITHUB_REF_NAME", "main")
+    
+    # Generate MCP configuration
+    config = {
+        "mcpServers": {
+            "github-file-ops": {
+                "command": "python",
+                "args": [
+                    os.path.join(os.environ.get("GITHUB_ACTION_PATH", ""), "src/mcp/github_file_ops_server.py")
+                ],
+                "env": {
+                    "GITHUB_TOKEN": github_token,
+                    "REPO_OWNER": owner,
+                    "REPO_NAME": repo_name,
+                    "BRANCH_NAME": branch,
+                    "PYTHONPATH": os.environ.get("GITHUB_ACTION_PATH", "")
+                }
+            }
+        }
+    }
+    
+    return json.dumps(config)
+
+
+def set_github_output(key: str, value: str) -> None:
+    """Set GitHub Actions output variable."""
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as f:
+            # For JSON values, we need to escape properly
+            if value.startswith("{"):
+                # Write as a single line without newlines
+                escaped_value = value.replace("\n", "")
+                f.write(f"{key}={escaped_value}\n")
+            else:
+                f.write(f"{key}={value}\n")
+    else:
+        # For local testing
+        print(f"{key}={value}")
+
+
+def main() -> None:
+    """Main function to prepare MCP configuration."""
+    mode = os.environ.get("DEVSY_MODE", "")
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    
+    if not mode:
+        print("❌ DEVSY_MODE environment variable not set")
+        sys.exit(1)
+    
+    if not github_token:
+        print("❌ GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+    
+    # Generate MCP configuration
+    mcp_config = generate_mcp_config(mode, github_token)
+    
+    # Set GitHub Actions output
+    set_github_output("mcp_config", mcp_config)
+    
+    if mode == "pr-update" and mcp_config != "{}":
+        print("✅ MCP configuration prepared for pr-update mode")
+        print("🔧 GitHub file operations server enabled")
+    else:
+        print("ℹ️  MCP server not needed for this mode")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/system-prompt-pr-update.md
+++ b/templates/system-prompt-pr-update.md
@@ -180,30 +180,32 @@ You have access to GitHub MCP tools for direct repository operations via GitHub 
 
 After addressing feedback, you must complete the full update cycle:
 
-### Required Git Workflow Operations
-1. **Branch Checkout**: First, ensure you're on the correct PR branch
+### File Update Workflows
+
+Choose one approach:
+
+#### Option A: GitHub API Tools (Recommended)
+- Use `mcp__github-file-ops__commit_files` to commit changes directly to GitHub
+- Use `mcp__github-file-ops__delete_files` to remove files directly on GitHub  
+- **No git commands needed** - changes go directly to the remote repository
+
+#### Option B: Traditional Git Workflow
+If using standard git commands:
+1. **Branch Checkout**: Ensure you're on the correct PR branch
    - Get the PR branch name: `gh pr view {{ pr_number }} --json headRefName -q .headRefName`
    - Check current branch: `git branch --show-current`
    - Switch to PR branch if needed: `git checkout <branch-name-from-step-1>`
-   - Verify you're on the correct branch before making any changes
 
 2. **File Updates**: **CRITICAL - You MUST commit ALL changes before completing**
    - Stage ALL changes: `git add .` to ensure no files are missed
-   - Write clear commit messages referencing the feedback addressed: `git commit -m "fix: address review feedback on error handling"`
-   - **Handle pre-commit hooks**: If commits fail due to formatting/linting changes:
-     * Pre-commit hooks may modify files (formatting, imports, etc.)
-     * Check `git status` after failed commit to see what changed
-     * Stage the hook-modified files: `git add .`
-     * Commit again: `git commit -m "fix: apply pre-commit formatting"`
-     * Repeat until commit succeeds with clean working directory
-   - Group related fixes into logical commits when possible
+   - Write clear commit messages: `git commit -m "fix: address review feedback on error handling"`
+   - Handle pre-commit hooks if commits fail due to formatting changes
    - **Verify no uncommitted changes**: Run `git status` to confirm working directory is clean
    - Push to update the remote branch: `git push origin <branch-name-from-checkout-step>`
-   - **NEVER leave uncommitted changes** - they won't be included in the PR update
 
 ### Required Post-Implementation Actions
 
-After successfully implementing all feedback and pushing changes:
+After successfully implementing all feedback and committing changes:
 
 #### 1. Summary Comment (Always Required)
 **You MUST add a comprehensive summary comment using `gh pr comment`.**
@@ -249,7 +251,7 @@ All requested changes have been implemented. The PR is ready for re-review.
 - Update description to include new implementation details
 - Prefix title updates to show evolution (e.g., "feat: add user auth" → "feat: add user auth with OAuth integration")
 
-### Available Git Commands
+### Available Git Commands (for traditional workflow)
 - `git add <files>` - Stage files for commit
 - `git commit -m "<message>"` - Create commits with messages
 - `git push origin <branch-name>` - Push changes to remote branch
@@ -264,13 +266,13 @@ All requested changes have been implemented. The PR is ready for re-review.
 
 ### Complete Update Strategy
 1. **Code Changes**: Make changes incrementally, addressing one type of feedback at a time
-2. **Commit & Push**: Commit frequently with descriptive messages, then push all changes
+2. **Commit Changes**: Use MCP tools or git workflow to commit changes with descriptive messages
 3. **Summary Comment**: **EXECUTE** `gh pr comment` to add comprehensive summary
 4. **Metadata Review**: **EXECUTE** `gh pr edit` if updates are warranted
 5. **Final Verification**: Ensure all feedback addressed and PR is ready for re-review
 
 ### Critical Error Handling
-**Commit Failures (Most Common Issue):**
+**Git Commit Failures (when using traditional git workflow):**
 - If `git commit` fails due to pre-commit hooks:
   1. Check `git status` - hooks may have modified files (formatting, linting, etc.)
   2. Stage hook-modified files: `git add .`

--- a/templates/system-prompt-pr-update.md
+++ b/templates/system-prompt-pr-update.md
@@ -72,6 +72,7 @@ You will analyze PR feedback, categorize and prioritize changes, implement updat
 ### Change Implementation
 - Use Edit for targeted, specific changes
 - Use MultiEdit for coordinated changes across multiple sections
+- **Use MCP GitHub file operations** (`mcp__github-file-ops__commit_files`) for changes requiring GitHub checks
 - Prefer incremental changes over wholesale rewrites
 - Maintain clear separation between different types of updates
 
@@ -163,7 +164,56 @@ You will analyze PR feedback, categorize and prioritize changes, implement updat
 
 ## GitHub Workflow Integration
 
-You have access to GitHub MCP tools for seamless PR update workflow. After addressing feedback, you must complete the full update cycle:
+You have access to advanced GitHub MCP tools for seamless PR update workflow. These tools enable direct GitHub API operations that can trigger GitHub checks when normal git operations might not.
+
+### Available GitHub Tools
+
+#### Standard Git Operations
+- Use standard git commands (`git add`, `git commit`, `git push`) for normal workflow
+
+#### Advanced GitHub MCP Tools (Preferred for PR Updates)
+When you need to ensure GitHub checks are triggered properly, use these MCP tools:
+
+- **`mcp__github-file-ops__commit_files`**: Commits files directly via GitHub API
+  - **When to use**: For important changes where GitHub checks must run (test updates, CI fixes, etc.)
+  - **Benefits**: Bypasses GitHub Actions commit restrictions, ensures checks trigger
+  - **Usage**: `mcp__github-file-ops__commit_files(message="Fix review feedback", files=[{"path": "file.py", "content": "file content"}])`
+
+- **`mcp__github-file-ops__delete_files`**: Deletes files directly via GitHub API  
+  - **When to use**: When removing files and checks need to run
+  - **Benefits**: Same as commit_files, ensures proper check triggering
+  - **Usage**: `mcp__github-file-ops__delete_files(message="Remove deprecated files", paths=["old_file.py"])`
+
+#### Tool Selection Strategy
+1. **Use MCP tools** when:
+   - Making test changes that need verification
+   - Fixing CI/build issues 
+   - Addressing critical feedback where checks are essential
+   - Previous pushes didn't trigger checks as expected
+
+2. **Use standard git** when:
+   - Making simple documentation updates
+   - Small style/formatting changes
+   - Multiple incremental commits before final push
+
+#### MCP Tool Usage Pattern
+```bash
+# Option 1: Read files, then use MCP to commit
+file_content = read_file("path/to/file.py")
+# ... modify content ...
+mcp__github-file-ops__commit_files(
+    message="fix: address reviewer feedback on error handling",
+    files=[{"path": "path/to/file.py", "content": modified_content}]
+)
+
+# Option 2: Delete files via MCP
+mcp__github-file-ops__delete_files(
+    message="remove: deprecated utility functions per review",
+    paths=["utils/deprecated.py", "tests/test_deprecated.py"]
+)
+```
+
+After addressing feedback, you must complete the full update cycle:
 
 ### Required Git Workflow Operations
 1. **Branch Checkout**: First, ensure you're on the correct PR branch

--- a/templates/system-prompt-pr-update.md
+++ b/templates/system-prompt-pr-update.md
@@ -72,7 +72,7 @@ You will analyze PR feedback, categorize and prioritize changes, implement updat
 ### Change Implementation
 - Use Edit for targeted, specific changes
 - Use MultiEdit for coordinated changes across multiple sections
-- **Use MCP GitHub file operations** (`mcp__github-file-ops__commit_files`) for changes requiring GitHub checks
+- Use MCP GitHub file operations (`mcp__github-file-ops__commit_files`) or standard git as preferred
 - Prefer incremental changes over wholesale rewrites
 - Maintain clear separation between different types of updates
 
@@ -164,54 +164,19 @@ You will analyze PR feedback, categorize and prioritize changes, implement updat
 
 ## GitHub Workflow Integration
 
-You have access to advanced GitHub MCP tools for seamless PR update workflow. These tools enable direct GitHub API operations that can trigger GitHub checks when normal git operations might not.
+You have access to GitHub MCP tools for direct repository operations via GitHub API.
 
-### Available GitHub Tools
+### Available Commit Tools
 
-#### Standard Git Operations
-- Use standard git commands (`git add`, `git commit`, `git push`) for normal workflow
-
-#### Advanced GitHub MCP Tools (Preferred for PR Updates)
-When you need to ensure GitHub checks are triggered properly, use these MCP tools:
-
+#### GitHub API Tools (Recommended)
 - **`mcp__github-file-ops__commit_files`**: Commits files directly via GitHub API
-  - **When to use**: For important changes where GitHub checks must run (test updates, CI fixes, etc.)
-  - **Benefits**: Bypasses GitHub Actions commit restrictions, ensures checks trigger
   - **Usage**: `mcp__github-file-ops__commit_files(message="Fix review feedback", files=[{"path": "file.py", "content": "file content"}])`
-
-- **`mcp__github-file-ops__delete_files`**: Deletes files directly via GitHub API  
-  - **When to use**: When removing files and checks need to run
-  - **Benefits**: Same as commit_files, ensures proper check triggering
+  
+- **`mcp__github-file-ops__delete_files`**: Deletes files directly via GitHub API
   - **Usage**: `mcp__github-file-ops__delete_files(message="Remove deprecated files", paths=["old_file.py"])`
 
-#### Tool Selection Strategy
-1. **Use MCP tools** when:
-   - Making test changes that need verification
-   - Fixing CI/build issues 
-   - Addressing critical feedback where checks are essential
-   - Previous pushes didn't trigger checks as expected
-
-2. **Use standard git** when:
-   - Making simple documentation updates
-   - Small style/formatting changes
-   - Multiple incremental commits before final push
-
-#### MCP Tool Usage Pattern
-```bash
-# Option 1: Read files, then use MCP to commit
-file_content = read_file("path/to/file.py")
-# ... modify content ...
-mcp__github-file-ops__commit_files(
-    message="fix: address reviewer feedback on error handling",
-    files=[{"path": "path/to/file.py", "content": modified_content}]
-)
-
-# Option 2: Delete files via MCP
-mcp__github-file-ops__delete_files(
-    message="remove: deprecated utility functions per review",
-    paths=["utils/deprecated.py", "tests/test_deprecated.py"]
-)
-```
+#### Standard Git Commands
+- Use `git add`, `git commit`, `git push` for traditional workflow when preferred
 
 After addressing feedback, you must complete the full update cycle:
 

--- a/tests/test_mcp_github_file_ops_server.py
+++ b/tests/test_mcp_github_file_ops_server.py
@@ -1,0 +1,219 @@
+"""Tests for the GitHub file operations MCP server."""
+
+import pytest
+from unittest.mock import patch, Mock
+import json
+import base64
+
+# Import the functions directly since the MCP decorators make testing harder
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'mcp'))
+from github_file_ops_server import make_github_request, commit_files, delete_files
+
+
+class TestMakeGithubRequest:
+    """Test the make_github_request helper function."""
+    
+    @patch('github_file_ops_server.requests.request')
+    def test_successful_request(self, mock_request):
+        """Test successful GitHub API request."""
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.text = '{"key": "value"}'
+        mock_response.json.return_value = {"key": "value"}
+        mock_request.return_value = mock_response
+        
+        result = make_github_request("GET", "https://api.github.com/test", "token123")
+        
+        assert result == {"key": "value"}
+        mock_request.assert_called_once_with(
+            method="GET",
+            url="https://api.github.com/test",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer token123",
+                "X-GitHub-Api-Version": "2022-11-28"
+            },
+            json=None
+        )
+    
+    @patch('github_file_ops_server.requests.request')
+    def test_failed_request(self, mock_request):
+        """Test failed GitHub API request."""
+        mock_response = Mock()
+        mock_response.ok = False
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_request.return_value = mock_response
+        
+        with pytest.raises(Exception, match="GitHub API error: 404 Not Found"):
+            make_github_request("GET", "https://api.github.com/test", "token123")
+
+
+class TestCommitFiles:
+    """Test the commit_files function."""
+    
+    @patch('github_file_ops_server.make_github_request')
+    def test_successful_commit(self, mock_github_request):
+        """Test successful file commit."""
+        # Mock the API responses in order
+        mock_github_request.side_effect = [
+            # Get branch reference
+            {"object": {"sha": "base123"}},
+            # Get base commit
+            {"tree": {"sha": "tree123"}},
+            # Create tree
+            {"sha": "newtree123"},
+            # Create commit
+            {"sha": "newcommit123", "html_url": "https://github.com/owner/repo/commit/newcommit123"},
+            # Update reference
+            {"ref": "refs/heads/main"}
+        ]
+        
+        result = commit_files(
+            message="Test commit",
+            files=[
+                {"path": "test.txt", "content": "Hello World"},
+                {"path": "README.md", "content": "# Test"}
+            ],
+            owner="testowner",
+            repo="testrepo",
+            branch="main",
+            github_token="token123"
+        )
+        
+        assert result["success"] is True
+        assert result["sha"] == "newcommit123"
+        assert result["url"] == "https://github.com/owner/repo/commit/newcommit123"
+        assert "2 file(s)" in result["message"]
+        
+        # Verify the tree creation call
+        tree_call = mock_github_request.call_args_list[2]
+        assert tree_call[0][0] == "POST"
+        assert "git/trees" in tree_call[0][1]
+        tree_data = tree_call[0][3]
+        assert tree_data["base_tree"] == "tree123"
+        assert len(tree_data["tree"]) == 2
+        assert tree_data["tree"][0]["path"] == "test.txt"
+        assert tree_data["tree"][0]["content"] == "Hello World"
+    
+    @patch('github_file_ops_server.make_github_request')
+    def test_commit_failure(self, mock_github_request):
+        """Test commit failure handling."""
+        mock_github_request.side_effect = Exception("API Error")
+        
+        result = commit_files(
+            message="Test commit",
+            files=[{"path": "test.txt", "content": "Hello"}],
+            owner="testowner",
+            repo="testrepo",
+            branch="main",
+            github_token="token123"
+        )
+        
+        assert result["success"] is False
+        assert "API Error" in result["error"]
+
+
+class TestDeleteFiles:
+    """Test the delete_files function."""
+    
+    @patch('github_file_ops_server.make_github_request')
+    def test_successful_delete(self, mock_github_request):
+        """Test successful file deletion."""
+        # Mock the API responses in order
+        mock_github_request.side_effect = [
+            # Get branch reference
+            {"object": {"sha": "base123"}},
+            # Get base commit
+            {"tree": {"sha": "tree123"}},
+            # Get current tree
+            {
+                "tree": [
+                    {"path": "keep.txt", "mode": "100644", "type": "blob", "sha": "sha1"},
+                    {"path": "delete.txt", "mode": "100644", "type": "blob", "sha": "sha2"},
+                    {"path": "also-delete.txt", "mode": "100644", "type": "blob", "sha": "sha3"}
+                ]
+            },
+            # Create new tree
+            {"sha": "newtree123"},
+            # Create commit
+            {"sha": "newcommit123", "html_url": "https://github.com/owner/repo/commit/newcommit123"},
+            # Update reference
+            {"ref": "refs/heads/main"}
+        ]
+        
+        result = delete_files(
+            message="Delete files",
+            paths=["delete.txt", "also-delete.txt"],
+            owner="testowner",
+            repo="testrepo",
+            branch="main",
+            github_token="token123"
+        )
+        
+        assert result["success"] is True
+        assert result["sha"] == "newcommit123"
+        assert "2 file(s)" in result["message"]
+        
+        # Verify the new tree only contains the kept file
+        tree_call = mock_github_request.call_args_list[3]
+        assert tree_call[0][0] == "POST"
+        assert "git/trees" in tree_call[0][1]
+        tree_data = tree_call[0][3]
+        assert len(tree_data["tree"]) == 1
+        assert tree_data["tree"][0]["path"] == "keep.txt"
+    
+    @patch('github_file_ops_server.make_github_request')
+    def test_delete_nonexistent_files(self, mock_github_request):
+        """Test deleting files that don't exist."""
+        # Mock the API responses
+        mock_github_request.side_effect = [
+            # Get branch reference
+            {"object": {"sha": "base123"}},
+            # Get base commit
+            {"tree": {"sha": "tree123"}},
+            # Get current tree (no files match the delete paths)
+            {
+                "tree": [
+                    {"path": "keep1.txt", "mode": "100644", "type": "blob", "sha": "sha1"},
+                    {"path": "keep2.txt", "mode": "100644", "type": "blob", "sha": "sha2"}
+                ]
+            },
+            # Create new tree
+            {"sha": "newtree123"},
+            # Create commit
+            {"sha": "newcommit123", "html_url": "https://github.com/owner/repo/commit/newcommit123"},
+            # Update reference
+            {"ref": "refs/heads/main"}
+        ]
+        
+        result = delete_files(
+            message="Delete files",
+            paths=["nonexistent.txt"],
+            owner="testowner",
+            repo="testrepo",
+            branch="main",
+            github_token="token123"
+        )
+        
+        assert result["success"] is True
+        assert "0 file(s)" in result["message"]
+    
+    @patch('github_file_ops_server.make_github_request')
+    def test_delete_failure(self, mock_github_request):
+        """Test delete failure handling."""
+        mock_github_request.side_effect = Exception("API Error")
+        
+        result = delete_files(
+            message="Delete files",
+            paths=["test.txt"],
+            owner="testowner",
+            repo="testrepo",
+            branch="main",
+            github_token="token123"
+        )
+        
+        assert result["success"] is False
+        assert "API Error" in result["error"]

--- a/tests/test_prepare_mcp_config.py
+++ b/tests/test_prepare_mcp_config.py
@@ -19,7 +19,7 @@ class TestGenerateMcpConfig:
             "GITHUB_REPOSITORY": "owner/repo",
             "GITHUB_REF_NAME": "feature-branch",
             "GITHUB_ACTION_PATH": "/path/to/action"
-        }):
+        }, clear=True):
             config_json = generate_mcp_config("pr-update", "token123")
             config = json.loads(config_json)
             
@@ -63,7 +63,7 @@ class TestGenerateMcpConfig:
             "GITHUB_HEAD_REF": "pr-branch",
             "GITHUB_REF_NAME": "main",
             "GITHUB_ACTION_PATH": "/path"
-        }):
+        }, clear=True):
             config_json = generate_mcp_config("pr-update", "token123")
             config = json.loads(config_json)
             assert config["mcpServers"]["github-file-ops"]["env"]["BRANCH_NAME"] == "pr-branch"

--- a/tests/test_prepare_mcp_config.py
+++ b/tests/test_prepare_mcp_config.py
@@ -1,0 +1,157 @@
+"""Tests for prepare_mcp_config.py script."""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, mock_open
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+from prepare_mcp_config import generate_mcp_config, set_github_output, main
+
+
+class TestGenerateMcpConfig:
+    """Test the generate_mcp_config function."""
+    
+    def test_pr_update_mode(self):
+        """Test MCP config generation for pr-update mode."""
+        with patch.dict(os.environ, {
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_REF_NAME": "feature-branch",
+            "GITHUB_ACTION_PATH": "/path/to/action"
+        }):
+            config_json = generate_mcp_config("pr-update", "token123")
+            config = json.loads(config_json)
+            
+            assert "mcpServers" in config
+            assert "github-file-ops" in config["mcpServers"]
+            
+            server_config = config["mcpServers"]["github-file-ops"]
+            assert server_config["command"] == "python"
+            assert server_config["args"][0] == "/path/to/action/src/mcp/github_file_ops_server.py"
+            assert server_config["env"]["GITHUB_TOKEN"] == "token123"
+            assert server_config["env"]["REPO_OWNER"] == "owner"
+            assert server_config["env"]["REPO_NAME"] == "repo"
+            assert server_config["env"]["BRANCH_NAME"] == "feature-branch"
+    
+    def test_pr_gen_mode(self):
+        """Test MCP config generation for pr-gen mode."""
+        config_json = generate_mcp_config("pr-gen", "token123")
+        assert config_json == "{}"
+    
+    def test_plan_gen_mode(self):
+        """Test MCP config generation for plan-gen mode."""
+        config_json = generate_mcp_config("plan-gen", "token123")
+        assert config_json == "{}"
+    
+    def test_invalid_repository(self):
+        """Test handling of invalid repository format."""
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": "invalid"}):
+            config_json = generate_mcp_config("pr-update", "token123")
+            assert config_json == "{}"
+    
+    def test_missing_repository(self):
+        """Test handling of missing repository."""
+        with patch.dict(os.environ, {}, clear=True):
+            config_json = generate_mcp_config("pr-update", "token123")
+            assert config_json == "{}"
+    
+    def test_head_ref_priority(self):
+        """Test that GITHUB_HEAD_REF takes priority over GITHUB_REF_NAME."""
+        with patch.dict(os.environ, {
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_HEAD_REF": "pr-branch",
+            "GITHUB_REF_NAME": "main",
+            "GITHUB_ACTION_PATH": "/path"
+        }):
+            config_json = generate_mcp_config("pr-update", "token123")
+            config = json.loads(config_json)
+            assert config["mcpServers"]["github-file-ops"]["env"]["BRANCH_NAME"] == "pr-branch"
+
+
+class TestSetGithubOutput:
+    """Test the set_github_output function."""
+    
+    def test_with_github_output_json(self):
+        """Test setting output with JSON value."""
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": "/tmp/output"}):
+            with patch("builtins.open", mock_open()) as mock_file:
+                set_github_output("mcp_config", '{"test": "value"}')
+                mock_file.assert_called_once_with("/tmp/output", "a", encoding="utf-8")
+                mock_file().write.assert_called_once_with('mcp_config={"test": "value"}\n')
+    
+    def test_with_github_output_string(self):
+        """Test setting output with string value."""
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": "/tmp/output"}):
+            with patch("builtins.open", mock_open()) as mock_file:
+                set_github_output("key", "value")
+                mock_file().write.assert_called_once_with("key=value\n")
+    
+    def test_without_github_output(self, capsys):
+        """Test local testing mode without GITHUB_OUTPUT."""
+        with patch.dict(os.environ, {}, clear=True):
+            set_github_output("key", "value")
+            captured = capsys.readouterr()
+            assert captured.out == "key=value\n"
+
+
+class TestMain:
+    """Test the main function."""
+    
+    def test_successful_pr_update(self, capsys):
+        """Test successful execution for pr-update mode."""
+        with patch.dict(os.environ, {
+            "DEVSY_MODE": "pr-update",
+            "GITHUB_TOKEN": "token123",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_ACTION_PATH": "/action"
+        }):
+            with patch("prepare_mcp_config.set_github_output") as mock_output:
+                main()
+                
+                # Verify output was set
+                mock_output.assert_called_once()
+                args = mock_output.call_args[0]
+                assert args[0] == "mcp_config"
+                assert "github-file-ops" in args[1]
+                
+                # Check console output
+                captured = capsys.readouterr()
+                assert "✅ MCP configuration prepared for pr-update mode" in captured.out
+                assert "🔧 GitHub file operations server enabled" in captured.out
+    
+    def test_successful_pr_gen(self, capsys):
+        """Test successful execution for pr-gen mode."""
+        with patch.dict(os.environ, {
+            "DEVSY_MODE": "pr-gen",
+            "GITHUB_TOKEN": "token123"
+        }):
+            with patch("prepare_mcp_config.set_github_output") as mock_output:
+                main()
+                
+                # Verify empty config was set
+                mock_output.assert_called_once_with("mcp_config", "{}")
+                
+                # Check console output
+                captured = capsys.readouterr()
+                assert "ℹ️  MCP server not needed for this mode" in captured.out
+    
+    def test_missing_mode(self, capsys):
+        """Test error when DEVSY_MODE is missing."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "token123"}, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+            assert exc_info.value.code == 1
+            captured = capsys.readouterr()
+            assert "❌ DEVSY_MODE environment variable not set" in captured.out
+    
+    def test_missing_token(self, capsys):
+        """Test error when GITHUB_TOKEN is missing."""
+        with patch.dict(os.environ, {"DEVSY_MODE": "pr-update"}, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+            assert exc_info.value.code == 1
+            captured = capsys.readouterr()
+            assert "❌ GITHUB_TOKEN environment variable not set" in captured.out


### PR DESCRIPTION
## Summary

This PR adds a custom Model Context Protocol (MCP) server that enables direct GitHub API file operations for the `pr-update` mode. This addresses the issue where GitHub Actions often won't trigger checks on PR updates, which can be problematic when you need CI/CD to run after devsy-action updates a PR.

### Key Changes

- **🔧 MCP Server Implementation**: Created `src/mcp/github_file_ops_server.py` with Python FastMCP
  - `commit_files` tool for direct GitHub API commits  
  - `delete_files` tool for direct GitHub API file deletions
  - Uses environment variables for GitHub repo context (owner, repo, branch, token)

- **⚙️ Dynamic MCP Configuration**: Added `src/prepare_mcp_config.py`
  - Only enables MCP server for `pr-update` mode
  - Generates JSON configuration dynamically based on GitHub context
  - Integrates with claude-code-base-action's MCP system

- **🔧 Tool Integration**: Updated `src/prepare_tools.py` 
  - Adds MCP tools (`mcp__github-file-ops__commit_files`, `mcp__github-file-ops__delete_files`) for pr-update mode
  - Maintains backward compatibility for other modes

- **📦 Dependencies**: Updated `requirements.txt`
  - Added `mcp[cli]>=1.0.0` and `uvloop>=0.17.0`

- **🧪 Comprehensive Testing**: Added full test coverage
  - `tests/test_mcp_github_file_ops_server.py` - 7 tests for MCP server functionality
  - `tests/test_prepare_mcp_config.py` - 13 tests for configuration generation
  - All 110 tests passing

- **📚 Documentation**: Updated `CLAUDE.md` with MCP server details

### How It Works

1. When `mode=pr-update`, the action now:
   - Generates MCP configuration with GitHub context
   - Starts the GitHub file operations MCP server
   - Makes MCP tools available to Claude Code

2. Claude Code can use `mcp__github-file-ops__commit_files` instead of normal git operations
   - This bypasses GitHub's action commit restrictions
   - Creates commits via GitHub API that should trigger checks normally

3. The approach mirrors [claude-code-action's implementation](https://github.com/anthropics/claude-code-action/blob/main/src/mcp/github-file-ops-server.ts) but in Python

### Testing

```bash
# Run all tests  
pytest -v

# Test MCP server specifically
pytest tests/test_mcp_github_file_ops_server.py -v

# Test MCP configuration
pytest tests/test_prepare_mcp_config.py -v
```

### Backward Compatibility

- No changes to existing functionality for `pr-gen` and `plan-gen` modes
- MCP server only runs when needed (pr-update mode)
- All existing inputs and outputs remain the same

🤖 Generated with [Claude Code](https://claude.ai/code)