### PR TITLE
Fix MCP server initialization failures

### DIFF
--- a/src/prepare_prompt.py
+++ b/src/prepare_prompt.py
@@ -97,7 +97,8 @@ def prepare_pr_update_prompt(pr_number, repo, token, custom_instructions, user_p
     return render_template(
         template,
         repo_name=repo,
-        base_branch=base_branch,
+        base_branch=pr_data["base"]["ref"],
+        head_branch=pr_data["head"]["ref"],
         pr_number=pr_number,
         pr_title=pr_data["title"],
         pr_body=pr_data["body"] or "No description provided.",

--- a/templates/pr-update.md
+++ b/templates/pr-update.md
@@ -2,8 +2,8 @@
 
 ## Repository Context
 - **Repository**: {{ repo_name }}
-- **Base Branch**: {{ base_branch }}
-- **Working Branch**: Continue working on existing PR branch
+- **Base Branch**: {{ base_branch }} (target branch for merge)
+- **Head Branch**: {{ head_branch }} (your working branch)
 
 ## Pull Request Context
 **PR #{{ pr_number }}: {{ pr_title }}**

--- a/tests/test_mcp_github_file_ops_server.py
+++ b/tests/test_mcp_github_file_ops_server.py
@@ -9,7 +9,7 @@ import base64
 import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'mcp'))
-from github_file_ops_server import make_github_request, commit_files, delete_files
+from github_file_ops_server import make_github_request, commit_files_impl, delete_files_impl
 
 
 class TestMakeGithubRequest:
@@ -52,7 +52,7 @@ class TestMakeGithubRequest:
 
 
 class TestCommitFiles:
-    """Test the commit_files function."""
+    """Test the commit_files_impl function."""
     
     @patch('github_file_ops_server.make_github_request')
     def test_successful_commit(self, mock_github_request):
@@ -71,7 +71,7 @@ class TestCommitFiles:
             {"ref": "refs/heads/main"}
         ]
         
-        result = commit_files(
+        result = commit_files_impl(
             message="Test commit",
             files=[
                 {"path": "test.txt", "content": "Hello World"},
@@ -103,7 +103,7 @@ class TestCommitFiles:
         """Test commit failure handling."""
         mock_github_request.side_effect = Exception("API Error")
         
-        result = commit_files(
+        result = commit_files_impl(
             message="Test commit",
             files=[{"path": "test.txt", "content": "Hello"}],
             owner="testowner",
@@ -117,7 +117,7 @@ class TestCommitFiles:
 
 
 class TestDeleteFiles:
-    """Test the delete_files function."""
+    """Test the delete_files_impl function."""
     
     @patch('github_file_ops_server.make_github_request')
     def test_successful_delete(self, mock_github_request):
@@ -144,7 +144,7 @@ class TestDeleteFiles:
             {"ref": "refs/heads/main"}
         ]
         
-        result = delete_files(
+        result = delete_files_impl(
             message="Delete files",
             paths=["delete.txt", "also-delete.txt"],
             owner="testowner",
@@ -189,7 +189,7 @@ class TestDeleteFiles:
             {"ref": "refs/heads/main"}
         ]
         
-        result = delete_files(
+        result = delete_files_impl(
             message="Delete files",
             paths=["nonexistent.txt"],
             owner="testowner",
@@ -206,7 +206,7 @@ class TestDeleteFiles:
         """Test delete failure handling."""
         mock_github_request.side_effect = Exception("API Error")
         
-        result = delete_files(
+        result = delete_files_impl(
             message="Delete files",
             paths=["test.txt"],
             owner="testowner",


### PR DESCRIPTION
## Summary
- Rewrote MCP server using proper `Server` class instead of `FastMCP`
- Fixed server startup to use async main() with stdio transport pattern
- Added proper tool schema definitions and handlers
- Updated pr-update template to show both base and head branches from actual PR data
- Fixed prepare_prompt to use PR's actual base/head branches instead of defaulting to "main"

## Problem
The MCP server was failing to initialize in production with status "failed". Investigation showed two issues:

1. **Wrong MCP pattern**: Using `FastMCP` instead of the proper `Server` class with `stdio_server` transport
2. **Wrong branch info**: pr-update mode always showed "main" as base branch instead of the PR's actual target branch

## Solution
1. **MCP Server Pattern**: Switched from `FastMCP` to the official `Server` class with `stdio_server()` transport, matching the pattern used in the official claude-code-action
2. **Branch Context**: Updated pr-update to extract and display actual base/head branches from GitHub PR API data
3. **Tool Definitions**: Added proper async handlers with complete tool schema definitions

## Test plan
- [x] All existing tests pass (110/110)
- [x] MCP server initializes without errors locally
- [x] Server creates proper initialization options
- [x] Tool schemas are properly defined
- [ ] Test in production environment to verify MCP server startup

🤖 Generated with [Claude Code](https://claude.ai/code)