### PR TITLE
feat: add dynamic git identity configuration for verified commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -130,9 +130,25 @@ runs:
 
     - name: Configure Git identity
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.token_exchange.outputs.github_token }}
       run: |
-        git config --global user.email "no-reply@devsy.ai"
-        git config --global user.name "Devsy Bot"
+        # Configure git identity based on the token source
+        if [ "${{ steps.token_exchange.outputs.token_source }}" = "devsy-bot" ]; then
+          # Get the bot's identity dynamically for verified commits
+          BOT_INFO=$(gh api user --jq '{login: .login, id: .id}')
+          BOT_LOGIN=$(echo "$BOT_INFO" | jq -r '.login')
+          BOT_ID=$(echo "$BOT_INFO" | jq -r '.id')
+          
+          git config --global user.email "${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
+          git config --global user.name "$BOT_LOGIN"
+          echo "✅ Configured git identity for $BOT_LOGIN (ID: $BOT_ID)"
+        else
+          # Fallback to generic identity
+          git config --global user.email "no-reply@devsy.ai"
+          git config --global user.name "Devsy Bot"
+          echo "✅ Configured git identity for Devsy Bot (fallback)"
+        fi
         # Configure Git to use HTTPS instead of SSH for GitHub repositories
         # This enables pip to install private GitHub packages using the GitHub token
         git config --global url."https://github.com/".insteadOf git@github.com:


### PR DESCRIPTION
## Summary
- Add dynamic git identity configuration based on token source
- Enable verified commits when using devsy-bot GitHub App token
- Maintain fallback to generic identity for compatibility

## Changes
- **Dynamic Identity Detection**: Configure git identity based on whether devsy-bot or fallback token is used
- **GitHub API Integration**: Use `gh api user` to fetch actual bot login and ID dynamically
- **Proper Email Format**: Use GitHub's standard format `{ID}+{LOGIN}@users.noreply.github.com` for verification
- **Logging**: Add clear output showing which identity configuration is being used
- **Fallback Support**: Maintain existing generic identity when devsy-bot is unavailable

## Technical Details
When `token_source` is `devsy-bot`:
- Dynamically fetches bot identity via GitHub API
- Sets git user.name to actual bot login (e.g., `devsy-bot[bot]`)
- Sets git user.email to verification-compatible format
- Results in ✅ **VERIFIED** commits attributed to the actual bot

When `token_source` is `github-actions-bot` (fallback):
- Uses existing generic "Devsy Bot" identity
- Maintains backward compatibility

## Test Plan
- [ ] Test with devsy-bot token to verify commits show as verified
- [ ] Test fallback behavior with standard GitHub Actions token
- [ ] Verify git identity is set correctly in both scenarios
- [ ] Confirm commits are properly attributed to the bot account

🤖 Generated with [Claude Code](https://claude.ai/code)