### PR TITLE
Add Claude Code OAuth token support for Max Plan users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Example usage:
     mode: pr-review
     pr_number: 123
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # Alternative to API key
 ```
 
 ## Quick Setup 
@@ -69,13 +70,23 @@ Enable GitHub Actions to create pull requests:
 
 #### Step 3: Add Your API Key
 
-Add your Anthropic API key to repository secrets:
+Add your Claude authentication to repository secrets (choose one):
 
+**Option 1: Anthropic API Key**
 1. **Get API Key**: Visit [console.anthropic.com](https://console.anthropic.com)
 2. **Add Secret**: Go to **Settings** → **Secrets and variables** → **Actions**
 3. **Create**: Click **"New repository secret"**
    - **Name**: `ANTHROPIC_API_KEY`
-   - **Value**: Your API key
+   - **Value**: Your API key from console.anthropic.com
+
+**Option 2: Claude Code OAuth Token (Recommended for Max Plan users)**
+1. **Get OAuth Token**: Run `claude auth` in Claude Code CLI to get your OAuth token
+2. **Add Secret**: Go to **Settings** → **Secrets and variables** → **Actions**  
+3. **Create**: Click **"New repository secret"**
+   - **Name**: `CLAUDE_CODE_OAUTH_TOKEN`
+   - **Value**: Your OAuth token from Claude Code CLI
+
+> OAuth tokens use flat pricing for Max Plan subscribers, while API keys use per-token billing.
 
 #### Step 4: Enable Callbacks
 
@@ -290,9 +301,9 @@ Templates use `{{ variable }}` syntax for variable substitution and can be custo
 ### "Authentication required" Error
 
 If you see an authentication error, ensure you have:
-- Added `ANTHROPIC_API_KEY` to your repository secrets
-- The secret name is exactly `ANTHROPIC_API_KEY` (case-sensitive)
-- Your API key is valid and has sufficient credits
+- Added `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` to your repository secrets
+- The secret name is exactly correct (case-sensitive)
+- Your credentials are valid and have sufficient credits/access
 - Or configured alternative authentication (Bedrock/Vertex)
 
 ### "No changes were made by Claude Code"

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,11 @@ inputs:
   # === Claude Base Action Configuration ===
   anthropic_api_key:
     description: "Anthropic API key for Claude"
-    required: true
+    required: false
+  claude_code_oauth_token:
+    description: "Claude Code OAuth token (alternative to anthropic_api_key)"
+    required: false
+    default: ""
   model:
     description: "Claude model to use"
     required: false
@@ -137,6 +141,7 @@ runs:
       env:
         DEVSY_MODE: ${{ inputs.mode }}
         DEVSY_ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        DEVSY_CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         DEVSY_USE_BEDROCK: ${{ inputs.use_bedrock }}
         DEVSY_USE_VERTEX: ${{ inputs.use_vertex }}
         DEVSY_PROMPT: ${{ inputs.prompt }}
@@ -269,6 +274,7 @@ runs:
         prompt: ${{ fromJSON(steps.prepare_prompt.outputs.user_prompt) }}
         system_prompt: ${{ fromJSON(steps.prepare_prompt.outputs.system_prompt) }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         model: ${{ inputs.model }}
         max_turns: ${{ inputs.max_turns }}
         timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/src/validate_inputs.py
+++ b/src/validate_inputs.py
@@ -18,21 +18,22 @@ def validate_mode(mode: str) -> None:
 
 
 def validate_authentication(
-    anthropic_api_key: str, use_bedrock: str, use_vertex: str
+    anthropic_api_key: str, claude_code_oauth_token: str, use_bedrock: str, use_vertex: str
 ) -> None:
     """Validate authentication configuration."""
-    if not anthropic_api_key and use_bedrock != "true" and use_vertex != "true":
+    if not anthropic_api_key and not claude_code_oauth_token and use_bedrock != "true" and use_vertex != "true":
         error_lines = [
             "Error: Authentication required. Please provide one of:",
             "  - anthropic_api_key: Set up ANTHROPIC_API_KEY in repository secrets",
+            "  - claude_code_oauth_token: Set up CLAUDE_CODE_OAUTH_TOKEN in repository secrets",
             "  - use_bedrock: true (with appropriate AWS credentials)",
             "  - use_vertex: true (with appropriate GCP credentials)",
             "",
-            "To set up ANTHROPIC_API_KEY:",
+            "To set up authentication:",
             "  1. Go to your repository Settings > Secrets and variables > Actions",
             "  2. Click 'New repository secret'",
-            "  3. Name: ANTHROPIC_API_KEY",
-            "  4. Value: Your Anthropic API key from console.anthropic.com",
+            "  3. For API key: Name: ANTHROPIC_API_KEY, Value: Your API key from console.anthropic.com",
+            "  4. For OAuth: Name: CLAUDE_CODE_OAUTH_TOKEN, Value: Your OAuth token from Claude Code",
         ]
         for line in error_lines:
             print(line)
@@ -61,6 +62,7 @@ def main() -> None:
     # Read all parameters from environment variables
     mode = os.environ.get("DEVSY_MODE", "")
     anthropic_api_key = os.environ.get("DEVSY_ANTHROPIC_API_KEY", "")
+    claude_code_oauth_token = os.environ.get("DEVSY_CLAUDE_CODE_OAUTH_TOKEN", "")
     use_bedrock = os.environ.get("DEVSY_USE_BEDROCK", "false")
     use_vertex = os.environ.get("DEVSY_USE_VERTEX", "false")
     prompt = os.environ.get("DEVSY_PROMPT", "")
@@ -74,7 +76,7 @@ def main() -> None:
 
     # Run all validations
     validate_mode(mode)
-    validate_authentication(anthropic_api_key, use_bedrock, use_vertex)
+    validate_authentication(anthropic_api_key, claude_code_oauth_token, use_bedrock, use_vertex)
     validate_mode_requirements(mode, prompt, prompt_file, pr_number)
 
     print("✅ All input validations passed")

--- a/tests/test_validate_inputs.py
+++ b/tests/test_validate_inputs.py
@@ -36,28 +36,38 @@ class TestValidateAuthentication:
     def test_api_key_provided(self):
         """Test that API key authentication passes."""
         # Should not raise any exception
-        validate_authentication("sk-ant-123", "false", "false")
+        validate_authentication("sk-ant-123", "", "false", "false")
+
+    def test_oauth_token_provided(self):
+        """Test that OAuth token authentication passes."""
+        # Should not raise any exception
+        validate_authentication("", "oauth-token-123", "false", "false")
+
+    def test_both_tokens_provided(self):
+        """Test that both API key and OAuth token authentication passes."""
+        # Should not raise any exception
+        validate_authentication("sk-ant-123", "oauth-token-123", "false", "false")
 
     def test_bedrock_authentication(self):
         """Test that Bedrock authentication passes."""
         # Should not raise any exception
-        validate_authentication("", "true", "false")
+        validate_authentication("", "", "true", "false")
 
     def test_vertex_authentication(self):
         """Test that Vertex authentication passes."""
         # Should not raise any exception
-        validate_authentication("", "false", "true")
+        validate_authentication("", "", "false", "true")
 
     def test_no_authentication(self):
         """Test that no authentication raises SystemExit."""
         with pytest.raises(SystemExit) as exc_info:
-            validate_authentication("", "false", "false")
+            validate_authentication("", "", "false", "false")
         assert exc_info.value.code == 1
 
     def test_empty_api_key_string(self):
         """Test that empty string API key with no alternatives fails."""
         with pytest.raises(SystemExit) as exc_info:
-            validate_authentication("", "false", "false")
+            validate_authentication("", "", "false", "false")
         assert exc_info.value.code == 1
 
 


### PR DESCRIPTION
## Summary
- Add `claude_code_oauth_token` input parameter as alternative to `anthropic_api_key`
- Enable flat pricing for Max Plan subscribers vs per-token billing
- Maintain backward compatibility with existing API key workflows

## Changes Made
- ✅ Added `claude_code_oauth_token` input to action.yml (optional)
- ✅ Updated validation logic to accept either OAuth token OR API key
- ✅ Pass OAuth token to base action for automatic fallback handling
- ✅ Updated documentation with OAuth setup instructions
- ✅ Added comprehensive tests for OAuth token validation
- ✅ Made `anthropic_api_key` optional (was required)

## Authentication Options
Users can now choose between:
1. **API Key**: `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
2. **OAuth Token**: `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`
3. **Both**: Base action automatically prioritizes OAuth token

## Test Plan
- [x] All existing tests pass
- [x] New OAuth token validation tests added and passing
- [x] Documentation updated with setup instructions
- [x] Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)